### PR TITLE
scope list user resumes by folder

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -326,21 +326,17 @@ export async function getResumeUrl(filePath: string): Promise<string | null> {
 // List user's uploaded resumes
 export async function listUserResumes(userId: string): Promise<{ data?: any[]; error?: any }> {
 	try {
-		const { data, error } = await supabase.storage.from('resumes').list(`resumes`, {
-			limit: 100,
-			offset: 0
+		const { data, error } = await supabase.storage.from('resumes').list(userId, {
+			limit: 100
 		});
 
 		if (error) {
-			return { error };
+			return { data: null, error };
 		}
 
-		// Filter files that belong to this user
-		const userFiles = data?.filter((file) => file.name.startsWith(userId)) || [];
-
-		return { data: userFiles };
+		return { data, error: null };
 	} catch (err) {
-		return { error: err };
+		return { data: null, error: err };
 	}
 }
 


### PR DESCRIPTION
## Summary
- limit resume storage list to a user's folder for scoped retrieval
- remove client-side filtering and return direct data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Code style issues found in 34 files)*
- `npm run check` *(fails: svelte-check found 100 errors and 30 warnings in 18 files)*

------
https://chatgpt.com/codex/tasks/task_e_6895dec209e0832db59ba3b913aa6e44