### PR TITLE
Reset photo state after save

### DIFF
--- a/src/components/ProfileEditor.svelte
+++ b/src/components/ProfileEditor.svelte
@@ -22,14 +22,20 @@
 	export let username: string = '';
 	export let saveSuccess = false;
 
-	// Listen for save success from parent
-	$: if (!uploading && saveSuccess) {
-		if (saveSuccessTimeout) clearTimeout(saveSuccessTimeout);
-		saveSuccessTimeout = setTimeout(() => {
-			saveSuccess = false;
-			saveSuccessTimeout = null;
-		}, 3000);
-	}
+        // Listen for save success from parent
+        $: if (!uploading && saveSuccess) {
+                if (profilePhotoUrl) {
+                        URL.revokeObjectURL(profilePhotoUrl);
+                        profilePhotoUrl = '';
+                }
+                profilePhotoFile = null;
+
+                if (saveSuccessTimeout) clearTimeout(saveSuccessTimeout);
+                saveSuccessTimeout = setTimeout(() => {
+                        saveSuccess = false;
+                        saveSuccessTimeout = null;
+                }, 3000);
+        }
 
 	let profilePhotoFile: File | null = null;
 	let profilePhotoUrl = '';


### PR DESCRIPTION
## Summary
- Reset `profilePhotoFile` and preview URL when a parent component reports a successful save to avoid stale previews and free memory.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Code style issues found in 34 files)*
- `npm run check` *(fails: svelte-check found 98 errors and 30 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6895e589ceb4832da300e9a684121472