### PR TITLE
fix: use nested photo_url in dashboard save handlers

### DIFF
--- a/src/routes/dashboard/editor/+page.svelte
+++ b/src/routes/dashboard/editor/+page.svelte
@@ -181,7 +181,7 @@
 		toasts.info('Saving profile changes...');
 
 		try {
-			let photoUrl = eventData.resumeData.photo_url || profile?.photo_url;
+                       let photoUrl = eventData.resumeData.photo_url || profile?.data?.photo_url;
 
 			// Handle image upload if a new photo is provided
 			if (eventData.profilePhoto) {

--- a/src/routes/dashboard/profile/+page.svelte
+++ b/src/routes/dashboard/profile/+page.svelte
@@ -215,7 +215,7 @@
 		try {
 			// Starting save process
 
-			let photoUrl = eventData.resumeData.photo_url || profile?.photo_url;
+                       let photoUrl = eventData.resumeData.photo_url || profile?.data?.photo_url;
 
 			// Handle image upload if a new photo is provided
 			if (eventData.profilePhoto) {


### PR DESCRIPTION
## Summary
- reference `photo_url` from profile data when saving dashboard editor or profile changes
- ensure save handlers fall back to stored `photo_url` before uploading new image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*


------
https://chatgpt.com/codex/tasks/task_e_6895e5886988832db68490513f0ecde1